### PR TITLE
Add Eclipse m2e lifecycle mapping metadata

### DIFF
--- a/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>generate</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnConfiguration>true</runOnConfiguration>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
The Maven plugin now "attaches" itself automatically to the m2e builder in Eclipse. Currently, this enables it to automatically add target/generated-test-sources/record-matchers to the Eclipse project's source folders, removing the need for separately configuring the builder-helper-maven-plugin for this for automatic discovery in Eclipse.i

Generating the matcher code must still be done with a Maven build. Apparently, when executing the Mojo in Eclipse, the classpath scanner does not find anything, so I am guessing there are something variance kicking in with the way the URLClassLoader for the scanner is built when executing within Eclipse.

https://eclipse.dev/m2e/documentation/m2e-making-maven-plugins-compat.html

